### PR TITLE
fix: conflict course detect

### DIFF
--- a/src/components/searchTab/Table.svelte
+++ b/src/components/searchTab/Table.svelte
@@ -25,6 +25,22 @@
     infos.forEach(info => {
       let position = getPosition(info.start, info.end, info.weekday)
       let key = getPositionString(position)
+      let tmpStart = parseInt(key[0], 10)
+      let tmpEnd = parseInt(key[1], 10)
+      let count =  tmpEnd - tmpStart
+      if (count == 3) {
+        let tmpKey = String(tmpStart) + String(tmpEnd - 1) + key[2]
+        if ($courses.has(tmpKey)) {
+          conflictKeys.push(tmpKey)
+          conflict = true
+        }
+      } else if (count == 2) {
+        let tmpKey = String(tmpStart) + String(tmpEnd + 1) + key[2]
+        if ($courses.has(tmpKey)) {
+          conflictKeys.push(tmpKey)
+          conflict = true
+        }
+      }
       if ($courses.has(key)) {
         conflictKeys.push(key)
         conflict = true

--- a/src/components/searchTab/Table.svelte
+++ b/src/components/searchTab/Table.svelte
@@ -41,6 +41,11 @@
           conflict = true
         }
       }
+      let tmpKey = String(tmpStart - 1) + String(tmpEnd) + key[2]
+      if ($courses.has(tmpKey)) {
+        conflictKeys.push(tmpKey)
+        conflict = true
+      }
       if ($courses.has(key)) {
         conflictKeys.push(key)
         conflict = true


### PR DESCRIPTION
当选择某一天的两节课：
1. 10:00-11:35
2. 10:00-12:25
出现冲突无法选择

解决方案：
x 为某一天
`1` 的 key 为 `46x`
`2` 的 key 为 `47x`

添加 `1` 时，即两节课，检测是否存在 `47x` 和 `36x` 的 key
添加 `2` 时，即三节课，检测是否存在 `46x` 和 `57x` 的 key